### PR TITLE
Update SenderID format

### DIFF
--- a/spec/Drivers/AwsSpec.php
+++ b/spec/Drivers/AwsSpec.php
@@ -60,7 +60,12 @@ class AwsSpec extends ObjectBehavior
             'content' => 'Just testing',
         ];
         $args = [
-            "SenderID" => $msg['from'],
+            'MessageAttributes' => [
+                'AWS.SNS.SMS.SenderID' => [
+                       'DataType' => 'String',
+                       'StringValue' => $msg['from']
+                ]
+             ],
             "SMSType" => "Transactional",
             "Message" => $msg['content'],
             "PhoneNumber" => $msg['to']

--- a/src/Drivers/Aws.php
+++ b/src/Drivers/Aws.php
@@ -94,7 +94,12 @@ class Aws implements Driver
     {
         try {
             $args = array(
-                "SenderID" => $message['from'],
+                'MessageAttributes' => [
+                    'AWS.SNS.SMS.SenderID' => [
+                           'DataType' => 'String',
+                           'StringValue' => $message['from']
+                    ]
+                 ],
                 "SMSType" => "Transactional",
                 "Message" => $message['content'],
                 "PhoneNumber" => $message['to']


### PR DESCRIPTION
As per issue here:
https://stackoverflow.com/questions/43605977/senderid-using-amazon-web-services-php-sdk/43748448#43748448

The SenderID has been moved to `MessageAttributes` key for array.